### PR TITLE
corrected gulp command per developer chat session

### DIFF
--- a/.build_scripts/build.sh
+++ b/.build_scripts/build.sh
@@ -3,7 +3,7 @@ set -e # halt script on error
 
 if [ $TRAVIS_PULL_REQUEST = "false" ] && [ $TRAVIS_BRANCH = ${DEPLOY_BRANCH} ]; then
   echo "Building site"
-  gulp prod
+  gulp build
 else
   echo "Not building, so long and thanks for all the fish!"
 fi


### PR DESCRIPTION
This PR changes the Travis build script to use `gulp build` instead of `gulp prod`, per discussion on chat with the contractor.