### PR TITLE
updated css to adjust placement of indicator categories/company names

### DIFF
--- a/app/assets/styles/04-pages/_04-category.scss
+++ b/app/assets/styles/04-pages/_04-category.scss
@@ -120,10 +120,10 @@
 							text {
 							transform: rotate(-90deg);
 						        @include media(small-up) {
-						        transform: rotate(-90deg);	
+						        transform: rotate(-90deg) translate(-10px);	
 						        }
 						        @include media(medium-up) {
-								transform: rotate(-35deg);				  
+								transform: rotate(-35deg) translate(-10px);				  
 						        }
 						        @include media(large-up) {
 								transform: rotate(-35deg);


### PR DESCRIPTION
@gutermul This PR should move the indicator labels -10px left so they aren't overlapping with other elements. I have not tested this locally in preview, so I would suggest building and serving locally to preview.